### PR TITLE
Added blocking for desktop,Android and IOS sync clients instructions

### DIFF
--- a/NextCloud.md
+++ b/NextCloud.md
@@ -150,6 +150,23 @@ Adding external storage e.g. Mount Samba shares
 -   Domain = SCHOOLCODE (NetBIOS name for your domain - the part before `.ad.sd57.bc.ca` in your domain name)
 -   Repeat for each share you want the user to have access to.
 
+# Block Desktop, Android and IOS Client Access, Only allow web access
+- Back to NextCloud as Admin, click on the gear (top right corner) and select "Admin"
+- On left click on "File access control
+
+- Click on Add rule group and type "Desktop Client"
+- Click on Add rule and select "Request user agent" from the pull down list.
+- On the next box to your right select "is" from the pull down list.
+- On the next box to your right slect "Desktop Client" from the pull down list.
+- Click on Add rule group and type "IOS Client"
+- Click on Add rule and select "Request user agent" from the pull down list.
+- On the next box to your right select "is" from the pull down list.
+- On the next box to your right slect "IOS Client" from the pull down list.
+- Click on Add rule group and type "Android Client"
+- Click on Add rule and select "Request user agent" from the pull down list.
+- On the next box to your right select "is" from the pull down list.
+- On the next box to your right slect "Android Client" from the pull down list.
+
 # Increasing upload file limit
 
 -   Edit `/var/www/nextcloud/.htaccess`


### PR DESCRIPTION
I've only tested the sync blocking on hhld using win7 and on a S6 android. Jan has tested with his iphone. Maybe we should try installing the nextcloud client on a win10 machine and checking it's blocked? I don't have access to win10 right now, if someone else does, my user is kdempsey, password Let.... dd